### PR TITLE
Edit URL, navbar fixes

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -37,11 +37,9 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/tuva-health/thetuvaproject.com/tree/main/packages/create-docusaurus/templates/shared/'
-          // 'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
+            'https://github.com/tuva-health/knowledge_base/edit/main/'
         },
         blog: {
           showReadingTime: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -72,14 +72,16 @@ const config = {
             label: 'Knowledge',
           },
           {
-            href: 'https://github.com/tuva-health',
+            to: 'https://github.com/tuva-health',
             label: 'Code',
             position: 'left',
+            target: null,
           },
           {
-            href: 'https://join.slack.com/t/thetuvaproject/shared_invite/zt-16iz61187-G522Mc2WGA2mHF57e0il0Q',
+            to: 'https://join.slack.com/t/thetuvaproject/shared_invite/zt-16iz61187-G522Mc2WGA2mHF57e0il0Q',
             label: 'Community',
             position: 'left',
+            target: null,
           },
           {to: '/blog', label: 'Blog', position: 'left'},
 


### PR DESCRIPTION
## What' here

* Edit page now points to correct GitHub urls (fixes #2)
* disabled external link icons in navbar (fixes #1)
* external links now open in existing tab (fixes #5)