### PR TITLE
Update CMS-1500 Form link

### DIFF
--- a/docs/claims-data-fundamentals/claims-data-elements.md
+++ b/docs/claims-data-fundamentals/claims-data-elements.md
@@ -10,7 +10,7 @@ Healthcare claims are created when a healthcare provider populates a claim form 
 - Also Known As: Professional claim
 - Electronic Version: 837P
 - Maintained By: National Uniform Claim Committee (NUCC)
-- Example Form: [https://nucc.org/images/stories/PDF/cms_1500_sample.pdf](https://nucc.org/images/stories/PDF/cms_1500_sample.pdf)
+- Example Form: [https://nucc.org/images/stories/PDF/1500_claim_form_2012_02.pdf](https://nucc.org/images/stories/PDF/1500_claim_form_2012_02.pdf)
 - Used By: Physicians, lab test companies, durable medical equipment companies, etc.
 
 **CMS-1450**


### PR DESCRIPTION
"Version 02/12 1500 Claim Form went into effect April 1, 2014." https://nucc.org/index.php/1500-claim-form-mainmenu-35

The existing link is for Version 08/05 1500 Claim Form which NUCC refers to as the "old version of the claim form". https://nucc.org/index.php/1500-claim-form-mainmenu-35/08-05-1500-claim-form