### PR TITLE
prefer union all for disjoint sets

### DIFF
--- a/docs/tuva-data/example-sql.md
+++ b/docs/tuva-data/example-sql.md
@@ -268,7 +268,7 @@ select
 from readmissions.readmission_summary
 where index_admission_flag = 1
 
-union
+union all
 
 select 
     2 as id
@@ -278,7 +278,7 @@ from readmissions.readmission_summary
 where index_admission_flag = 1 
     and unplanned_readmit_30_flag = 1
     
-union
+union all
 
 select 
     3 as id
@@ -288,7 +288,7 @@ from readmissions.readmission_summary
 where index_admission_flag = 1 
     and unplanned_readmit_30_flag = 1
 
-union
+union all
 
 select 
     4 as id
@@ -298,7 +298,7 @@ from readmissions.readmission_summary
 where index_admission_flag = 1 
     and unplanned_readmit_30_flag = 1
     
-union
+union all
 
 select 
     5 as id
@@ -308,7 +308,7 @@ from readmissions.readmission_summary
 where index_admission_flag = 1 
     and unplanned_readmit_30_flag = 1
     
-union
+union all
 
 select 
     6 as id


### PR DESCRIPTION
`union all` is more performant for disjoint sets (because it doesn't need to compare the two sets). 

For example code, I don't think that matters all that much, but I do think it helps with clarity (if anyone is reading the SQL that will know that the component queries that are being unioned will not overlap.

<details>
<summary> validation code </summary>
returns 0 rows
```
with original as( 
-- Simple readmission statistics
select 
    1 as id
,   'Index Admissions' as measure
,   count(1) as value
from readmissions.readmission_summary
where index_admission_flag = 1
union
select 
    2 as id
,   'Unplanned 30-day Readmissions' as measure
,   count(1) as value
from readmissions.readmission_summary
where index_admission_flag = 1 
    and unplanned_readmit_30_flag = 1
union
select 
    3 as id
,   'Avg Days to Readmission' as measure
,   avg(days_to_readmit) as value
from readmissions.readmission_summary
where index_admission_flag = 1 
    and unplanned_readmit_30_flag = 1
union
select 
    4 as id
,   'Readmission Avg Length of Stay' as measure
,   avg(readmission_length_of_stay) as value
from readmissions.readmission_summary
where index_admission_flag = 1 
    and unplanned_readmit_30_flag = 1
union
select 
    5 as id
,   'Readmission Mortalities' as measure
,   sum(died_flag) as value
from readmissions.readmission_summary
where index_admission_flag = 1 
    and unplanned_readmit_30_flag = 1
union
select 
    6 as id
,   'Readmission Avg Paid Amount' as measure
,   cast(avg(paid_amount) as numeric(38,0)) as value
from readmissions.readmission_summary
where index_admission_flag = 1 
    and unplanned_readmit_30_flag = 1
order by 1
),
proposed_version as (
-- Simple readmission statistics
select 
    1 as id
,   'Index Admissions' as measure
,   count(1) as value
from readmissions.readmission_summary
where index_admission_flag = 1
union all
select 
    2 as id
,   'Unplanned 30-day Readmissions' as measure
,   count(1) as value
from readmissions.readmission_summary
where index_admission_flag = 1 
    and unplanned_readmit_30_flag = 1
union all
select 
    3 as id
,   'Avg Days to Readmission' as measure
,   avg(days_to_readmit) as value
from readmissions.readmission_summary
where index_admission_flag = 1 
    and unplanned_readmit_30_flag = 1
union all
select 
    4 as id
,   'Readmission Avg Length of Stay' as measure
,   avg(readmission_length_of_stay) as value
from readmissions.readmission_summary
where index_admission_flag = 1 
    and unplanned_readmit_30_flag = 1
union all
select 
    5 as id
,   'Readmission Mortalities' as measure
,   sum(died_flag) as value
from readmissions.readmission_summary
where index_admission_flag = 1 
    and unplanned_readmit_30_flag = 1
union all
select 
    6 as id
,   'Readmission Avg Paid Amount' as measure
,   cast(avg(paid_amount) as numeric(38,0)) as value
from readmissions.readmission_summary
where index_admission_flag = 1 
    and unplanned_readmit_30_flag = 1
order by 1
)
(select * from original 
except select * from proposed_version)
union all
(select * from proposed_version 
except select * from original)
```
</details>