### PR TITLE
Fix blog card link for same-day readmits post

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -1,7 +1,7 @@
 <section class="landing-shell">
 <div class="article-grid" id="article-grid">
 <article class="article-card" data-search="Measuring Same-Day Readmits How to measure same-day readmits for acute inpatient encounters in Tuva, including discharge-status patterns and same-primary-diagnosis checks. Aaron Neiderhiser Andreas Martinson">
-<a href="./measuring-same-day-readmits.html" class="article-card-link">
+<a href="https://www.thetuvaproject.com/blog/measuring-same-day-readmits" class="article-card-link">
 <img src="img/blog/same-day-readmits.png" alt="Measuring Same-Day Readmits" />
 <div class="card-body">
 <h3>Measuring Same-Day Readmits</h3>


### PR DESCRIPTION
Summary: fix the blog homepage card link to use /blog/measuring-same-day-readmits so production routes correctly and avoids root-path 404. Validation: rendered index.qmd and confirmed generated link in _book/index.html.